### PR TITLE
Calling stylesheet_link_tag with a symbol raises "no implicit conversion of Symbol into String"

### DIFF
--- a/lib/sprockets_better_errors/sprockets_rails_helper.rb
+++ b/lib/sprockets_better_errors/sprockets_rails_helper.rb
@@ -89,7 +89,7 @@ module Sprockets::Rails::Helper
     # Returns true when an asset will not available after precompile is run
     def asset_needs_precompile?(source, filename)
       return true  unless Sprockets::Rails::Helper.assets
-      return false if Sprockets::Rails::Helper.assets.send(:matches_filter, Sprockets::Rails::Helper.precompile || [], source, filename)
+      return false if Sprockets::Rails::Helper.assets.send(:matches_filter, Sprockets::Rails::Helper.precompile || [], source.to_s, filename)
       true
     end
 end


### PR DESCRIPTION
Some gems use the stylesheet helper with a symbol. For example, the `xray-rails` gem uses this code:

```
<%= stylesheet_link_tag :xray %>
```

This would cause the underlying Sprockets code (v2.10.1) to raise the following error: "no implicit conversion of Symbol into String".

Solve this by converting the source (:xray in the above example) to a string before passing it to Sprockets.
