### PR TITLE
Reference first post in backport thread

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ That would be AMAZING! Well this gem adds these types of helpful errors!
 
 ## Compatibility
 
-If you're using Rails 3.2 you will need to [enable the Rails 4 asset pipeline in Rails 3](https://discussion.heroku.com/t/using-the-rails-4-asset-pipeline-in-rails-3-apps-for-faster-deploys/205/3). Works out of the box with Rails 4.
+If you're using Rails 3.2 you will need to [enable the Rails 4 asset pipeline in Rails 3](https://discussion.heroku.com/t/using-the-rails-4-asset-pipeline-in-rails-3-apps-for-faster-deploys/205). Works out of the box with Rails 4.
 
 ## Install
 


### PR DESCRIPTION
The link provided in the README is to the third post on the thread which is not ideal since the first post has all the info
