### PR TITLE
Limit to Rails < 4.1 without adding new dependencies

### DIFF
--- a/sprockets_better_errors.gemspec
+++ b/sprockets_better_errors.gemspec
@@ -28,7 +28,10 @@ MSG
 
   gem.post_install_message = msg
 
-  gem.add_dependency 'sprockets-rails', ">= 1.0.0"
+  gem.add_dependency "sprockets-rails", ">= 1.0.0"
+  gem.add_dependency "actionpack", "< 4.1"
+  gem.add_dependency "activesupport", "< 4.1"
+
   gem.add_development_dependency "capybara", ">= 0.4.0"
   gem.add_development_dependency "launchy", "~> 2.1.0"
   gem.add_development_dependency "poltergeist"


### PR DESCRIPTION
per https://github.com/rails/sprockets-rails/pull/96#issuecomment-39873564

I know that technically `< 4.1` is not sufficient, but given that the dependency `sprockets-rails` depends on  `actionpack >= 3.0` and `activesupport >= 3.0` I thought this sufficient
