### PR TITLE
Careful version check for rails 3.2 special dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ end
 
 gem "rails", rails
 
-if rails_version.include?("3.2")
+if rails_version.match(/^3\.2/)
   gem 'sprockets', '2.2.2.backport2'
   gem 'sprockets-rails', '2.0.0.backport1'
 end


### PR DESCRIPTION
If a rails `*.3.2` ever comes out (e.g. 4.3.2) we don't want it to match.

Not urgent, obviously, just something I noticed while looking at the recent `< 4.1` change (https://github.com/schneems/sprockets_better_errors/pull/14)
